### PR TITLE
GeoIP2 support

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -16,6 +16,7 @@ WriteMakefile(
         'Test::More'    => 0,
         'Plack'         => 0,
         'Geo::IP'       => 1.39,
+        'GeoIP2'        => 2.001003,
     },
     META_MERGE => {
         resources => {

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -16,7 +16,7 @@ WriteMakefile(
         'Test::More'    => 0,
         'Plack'         => 0,
         'Geo::IP'       => 1.39,
-        'GeoIP2'        => 2.001003,
+        'GeoIP2'        => 2.002000,
     },
     META_MERGE => {
         resources => {

--- a/lib/Plack/Middleware/GeoIP2.pm
+++ b/lib/Plack/Middleware/GeoIP2.pm
@@ -85,6 +85,14 @@ GEOIP_COUNTRY_CODE, GEOIP_COUNTRY_NAME, GEOIP_CONTINENT_CODE
   GeoIPDBFile => '/path/to/GeoIP.dat'
   GeoIPDBFile => [ '/path/to/GeoIP.dat', '/path/to/GeoIPCity.dat' ]
 
+Path to GeoIP2 data files.
+
+=item GeoIP2Locales
+
+  GeoIP2Locales => [ 'en', 'de' ]
+
+Array of locale names passed to GeoIP2, to localize GEOIP_COUNTRY_NAME.
+
 =back
 
 =head1 AUTHOR

--- a/lib/Plack/Middleware/GeoIP2.pm
+++ b/lib/Plack/Middleware/GeoIP2.pm
@@ -1,0 +1,107 @@
+package Plack::Middleware::GeoIP2;
+use strict;
+use warnings;
+use 5.008;
+our $VERSION = 0.03;
+use parent qw/Plack::Middleware/;
+use GeoIP2::Database::Reader;
+use Carp;
+
+use Plack::Util::Accessor qw( GeoIP2DBFile GeoIP2Locales );
+
+sub prepare_app {
+    my $self = shift;
+
+    my $locales = $self->GeoIP2Locales || ['en'];
+
+    if (my $dbfiles = $self->GeoIP2DBFile) {
+        my @dbfiles = ref $dbfiles ? @{ $dbfiles } : ($dbfiles);
+        foreach my $dbfile (@dbfiles) {
+            my $gi = GeoIP2::Database::Reader->new(
+                file => $dbfile,
+                locales => $locales,
+            );
+            push @{ $self->{gips} }, $gi;
+        }
+    }
+    else {
+        Carp::croak('GeoIP2 database not found!');
+    }
+}
+
+sub call {
+    my $self = shift;
+    my $env  = shift;
+
+    my $ipaddr = $env->{REMOTE_ADDR};
+
+    foreach my $gi (@{ $self->{gips} }) {
+        if (my $record = $gi->country( ip => $ipaddr ) ) {
+            $env->{GEOIP_COUNTRY_CODE} = $record->country->iso_code;
+            $env->{GEOIP_COUNTRY_NAME} = $record->country->name;
+            $env->{GEOIP_CONTINENT_CODE} = $record->continent->name;
+        }
+    }
+
+    return $self->app->($env);
+}
+
+1;
+
+=head1 NAME
+
+Plack::Middleware::GeoIP2 - Find country and city of origin of a web request
+
+=head1 SYNOPSIS
+
+  # with Plack::Middleware::RealIP
+  enable 'Plack::Middleware::RealIP',
+      header => 'X-Forwarded-For',
+      trusted_proxy => [ qw(192.168.1.0/24 192.168.2.1) ];
+  enable 'Plack::Middleware::GeoIP',
+      GeoIP2DBFile => [ '/path/to/GeoLite2-Country.mmdb', '/path/to/GeoIP2-Country.mmdb' ];
+
+=head1 DESCRIPTION
+
+Plack::Middleware::GeoIP2 is a version of Plack::Middleware::GeoIP using
+the more recent GeoIP2 library from MaxMind.
+
+All requests are looked up and GEOIP_* variables are added to PSGI
+environment hash. For improved performance, you may want to only enable
+this middleware for specific URL's.
+
+The following PSGI environment variables are set by this middleware:
+
+GeoIP Country Edition:
+
+GEOIP_COUNTRY_CODE, GEOIP_COUNTRY_NAME, GEOIP_CONTINENT_CODE
+
+=head1 CONFIGURATION
+
+=over 4
+
+=item GeoIPDBFile
+
+  GeoIPDBFile => '/path/to/GeoIP.dat'
+  GeoIPDBFile => [ '/path/to/GeoIP.dat', '/path/to/GeoIPCity.dat' ]
+  GeoIPDBFile => [ '/path/to/GeoIP.dat', [ '/path/to/GeoIPCity.dat', 'MemoryCache' ] ]
+  GeoIPDBFile => [ '/path/to/GeoIP.dat', [ '/path/to/GeoIPCity.dat', [ qw(MemoryCache CheckCache) ] ] ]
+
+=back
+
+=head1 AUTHOR
+
+Zak B. Elep E<lt>zakame@cpan.orgE<gt>
+
+=head1 LICENSE
+
+This library is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+=head1 SEE ALSO
+
+L<mod_geoip|http://www.maxmind.com/app/mod_geoip>
+
+L<GeoIP2>
+
+=cut

--- a/lib/Plack/Middleware/GeoIP2.pm
+++ b/lib/Plack/Middleware/GeoIP2.pm
@@ -84,8 +84,6 @@ GEOIP_COUNTRY_CODE, GEOIP_COUNTRY_NAME, GEOIP_CONTINENT_CODE
 
   GeoIPDBFile => '/path/to/GeoIP.dat'
   GeoIPDBFile => [ '/path/to/GeoIP.dat', '/path/to/GeoIPCity.dat' ]
-  GeoIPDBFile => [ '/path/to/GeoIP.dat', [ '/path/to/GeoIPCity.dat', 'MemoryCache' ] ]
-  GeoIPDBFile => [ '/path/to/GeoIP.dat', [ '/path/to/GeoIPCity.dat', [ qw(MemoryCache CheckCache) ] ] ]
 
 =back
 

--- a/t/geoip2.t
+++ b/t/geoip2.t
@@ -1,0 +1,65 @@
+#!/usr/bin/perl
+use strict;
+use Test::More;
+use Plack::Test;
+use Plack::Builder;
+use Plack::Request;
+use HTTP::Request::Common;
+
+my $Country_db;
+for my $file ('GeoLite2-Country.mmdb', '/usr/share/GeoIP/GeoLite2-Country.mmdb', '/var/lib/GeoIP/GeoLite2-Country.mmdb', '/usr/local/share/GeoIP/GeoLite2-Country.mmdb') {
+    $Country_db = $file, last if -f $file;
+}
+
+unless ($Country_db) {
+    plan skip_all => 'No GeoLite2-Country.mmdb found';
+}
+
+sub run {
+    my ($remote_addr, $expected_country) = @_;
+
+    my $app = builder {
+        enable sub {
+            my $app = shift;
+            sub { $_[0]->{REMOTE_ADDR} = $remote_addr; $app->($_[0]) };
+        };
+        enable 'Plack::Middleware::GeoIP2',
+            GeoIP2DBFile => $Country_db;
+        sub { return [ 200, [ 'Content-Type' => 'text/plain' ], [ $_[0]->{GEOIP_COUNTRY_CODE} ] ] };
+    };
+
+    test_psgi $app, sub {
+        my $cb = shift;
+        my $res = $cb->(GET '/');
+        is $res->content, $expected_country;
+    };
+}
+
+while (<DATA>) {
+    chomp;
+    my ($ip_addr, $expected_country) = split /\s+/;
+
+    run($ip_addr, $expected_country);
+}
+
+done_testing;
+
+__DATA__
+203.174.65.12	JP
+212.208.74.140	FR
+200.219.192.106	BR
+134.102.101.18	DE
+193.75.148.28	BE
+134.102.101.18	DE
+147.251.48.1	CZ
+194.244.83.2	IT
+203.15.106.23	AU
+196.31.1.1	ZA
+210.54.22.1	NZ
+210.25.5.5	CN
+210.54.122.1	NZ
+210.25.15.5	CN
+192.37.51.100	CH
+192.37.150.150	CH
+192.106.51.100	IT
+192.106.150.150	IT


### PR DESCRIPTION
This feature adds support for using the newer GeoIP2/GeoLite2 databases (via GeoIP2::Database::Reader.)