### PR TITLE
Handle GeoIP2::Database::Reader exceptions

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -17,7 +17,6 @@ WriteMakefile(
         'Plack'         => 0,
         'Geo::IP'       => 1.39,
         'GeoIP2'        => 2.002000,
-        'Try::Tiny'     => 0,
     },
     META_MERGE => {
         resources => {

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -17,6 +17,7 @@ WriteMakefile(
         'Plack'         => 0,
         'Geo::IP'       => 1.39,
         'GeoIP2'        => 2.002000,
+        'Try::Tiny'     => 0,
     },
     META_MERGE => {
         resources => {

--- a/lib/Plack/Middleware/GeoIP2.pm
+++ b/lib/Plack/Middleware/GeoIP2.pm
@@ -8,7 +8,6 @@ use GeoIP2::Database::Reader;
 use Carp;
 
 use Plack::Util::Accessor qw( GeoIP2DBFile GeoIP2Locales );
-use Try::Tiny;
 
 sub prepare_app {
     my $self = shift;
@@ -37,13 +36,13 @@ sub call {
     my $ipaddr = $env->{REMOTE_ADDR};
 
     foreach my $gi (@{ $self->{gips} }) {
-        try {
+        eval {
             my $record = $gi->country( ip => $ipaddr );
             $env->{GEOIP_COUNTRY_CODE} = $record->country->iso_code;
             $env->{GEOIP_COUNTRY_NAME} = $record->country->name;
             $env->{GEOIP_CONTINENT_CODE} = $record->continent->name;
-        }
-        catch {
+        };
+        if ($@) {
             $env->{GEOIP_COUNTRY_CODE} = 'ZZ';
             $env->{GEOIP_COUNTRY_NAME} = 'Unknown Country';
             $env->{GEOIP_CONTINENT_CODE} = 'Unknown Continent';


### PR DESCRIPTION
This fixes an issue where when `REMOTE_ADDR` is a bad/local IP, the
GeoIP2::Database::Reader module will emit an exception.  For now, follow
the old GeoIP behavior of setting `ZZ` as the country code for
unrecognized IPs.
